### PR TITLE
Inclusão de meetups no Rio de Janeiro

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 ----
 ## Minas Gerais
 
-*Meetups sobre desenvolvimento web no estado do Rio Grande do Sul.*
+*Meetups sobre desenvolvimento web no estado de Minas Gerais.*
 
 * [UX - Belo Horizonte](http://www.meetup.com/UX-Belo-Horizonte/) - Meetup sobre UX organizado por [Pedro Marques](https://twitter.com/pedro_designer/)
 
@@ -52,7 +52,7 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 * [DevInterior - Ribeirão Preto](http://www.meetup.com/devinterior/) - Meetup sobre desenvolvimento em geral organizado por [Caio Tarifa](https://twitter.com/caiotarifa)
 * [FDG - Interior](http://www.meetup.com/fdginterior) - Meetup sobre desenvolvimento Front-End em geral. Organizado por [Christian Freitas](https://twitter.com/chrfreitas) e [Douglas Oliveira](https://twitter.com/doidz)
 * [FEMUG-SP](http://femug.com/cgi-bin/mailman/listinfo/sp) - Meetup sobre frontend organizado por [Daniel Filho](https://twitter.com/danielfilho)
-* [Meteor - São Paulo](http://www.meetup.com/Meteor-Sao-Paulo/) - Meetup sobre Meteor organizado por [Leonardo Grijó] (http://twitter.com/leonardogrijo)
+* [Meteor - São Paulo](http://www.meetup.com/Meteor-Sao-Paulo/) - Meetup sobre Meteor organizado por [Leonardo Grijó](http://twitter.com/leonardogrijo)
 * [NodeBR - São Paulo](http://www.meetup.com/NodeBR-Sao-Paulo/) - Meetup sobre Node.js organizado por [Allan Hoffmeister](https://twitter.com/alan_hoff)
 * [PHPSP](http://www.meetup.com/php-sp/) - Meetup sobre PHP organizado por [Anderson Casimiro](https://twitter.com/duodraco)
 * [Web Performance SP](http://www.meetup.com/Web-Performance-SP) - Meetup sobre performance organizado por Alex Soares


### PR DESCRIPTION
Além dos meetups de Javascript e Ruby on Rails incluí o Horaextra que embora não seja focado em nenhuma linguagem, é um encontro de desenvolvedores que acontece semanalmente em dois locais no Rio (Centro e Barra da Tijuca).
