### PR TITLE
Contributing.md, Meetups em ordem alfabética e espaçamento

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,5 +5,6 @@ Por favor, use um tempo para ler esse documento para fazer com que o processo de
 2. **Use o pull request search** &mdash; verifique se já não existe um pull request solicitado incluindo o mesmo meetup que você.
 3. **Respeite a ordem alfabética de Estados** &mdash; para manter a lista bem organizada, por favor, não coloque um novo Estado abaixo de tudo; verifique a ordem alfabética e o coloque seguindo esse padrão.
 4. **Respeite a ordem alfabética de Meetups** &mdash; para manter a lista bem organizada, por favor, não coloque um novo Meeutp abaixo de tudo; verifique a ordem alfabética e o coloque seguindo esse padrão.
+5. **A cada Meetup inserido deixe um espaço entre os outros** &mdash;  dessa forma melhora tanto a leitura quanto na hora de adicionar mais Meetups, pois não ficam grudados um no outro.
 
-Tendo em mente esses 4 pontos você respeita o tempo dos desenvolvedores que mantém esse projeto e o seu próprio tempo, já que aumenta a probabilidade de seu pull request ser aceito mais rápido, evitando assim refações de sua parte :smiley:
+Tendo em mente esses 5 pontos você respeita o tempo dos desenvolvedores que mantém esse projeto e o seu próprio tempo, já que aumenta a probabilidade de seu pull request ser aceito mais rápido, evitando assim refações de sua parte :smiley:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contribuindo
+Por favor, use um tempo para ler esse documento para fazer com que o processo de contribuição seja fácil e efetivo para todos os envolvidos.
+
+1. **Use o issue search** &mdash; verifique se já não existe a issue que você quer abrir.
+2. **Use o pull request search** &mdash; verifique se já não existe um pull request solicitado incluindo o mesmo meetup que você.
+3. **Respeite a ordem alfabética de Estados** &mdash; para manter a lista bem organizada, por favor, não coloque um novo Estado abaixo de tudo; verifique a ordem alfabética e o coloque seguindo esse padrão.
+4. **Respeite a ordem alfabética de Meetups** &mdash; para manter a lista bem organizada, por favor, não coloque um novo Meeutp abaixo de tudo; verifique a ordem alfabética e o coloque seguindo esse padrão.
+
+Tendo em mente esses 4 pontos você respeita o tempo dos desenvolvedores que mantém esse projeto e o seu próprio tempo, já que aumenta a probabilidade de seu pull request ser aceito mais rápido, evitando assim refações de sua parte :smiley:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Meetups
 
-Contribuições são bem vindas, mas antes de contribuir por favor, acesse nosso [guia de contribuição](https://github.com/cerebrobr/meetups/blob/master/CONTRIBUTING.md)
-
 Lista de meetups voltados para desenvolvimento web no Brasil.
+
+Contribuições são bem vindas, mas antes de contribuir por favor, acesse nosso [guia de contribuição](https://github.com/cerebrobr/meetups/blob/master/CONTRIBUTING.md)
 
 * [Bahia](#bahia)
 * [Minas Gerais](#minas-gerais)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Meetups
 
+Contribuições são bem vindas, mas antes de contribuir por favor, acesse nosso [guia de contribuição](https://github.com/cerebrobr/meetups/blob/master/CONTRIBUTING.md)
+
 Lista de meetups voltados para desenvolvimento web no Brasil.
 
 * [Bahia](#bahia)

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 
 *Meetups sobre desenvolvimento web no estado de Minas Gerais.*
 
-* [UX - Belo Horizonte](http://www.meetup.com/UX-Belo-Horizonte/) - Meetup sobre UX organizado por [Pedro Marques](https://twitter.com/pedro_designer/)
-* [WordPress - Belo Horizonte](http://www.meetup.com/WordPressBeloHorizonte) - Meetup sobre WordPress organizado por [https://twitter.com/valeriosza]
 * [devbeers - Belo Horizonte](http://www.meetup.com/devbeers-Belo-Horizonte/) - Meetup sobre desenvolvimento em geral organizado por [Beto Muniz](https://twitter.com/obetomuniz), [Luiz Mendes](https://twitter.com/lurimendes) e [Bruno Pulis](https://twitter.com/brunopulis)
+
+* [UX - Belo Horizonte](http://www.meetup.com/UX-Belo-Horizonte/) - Meetup sobre UX organizado por [Pedro Marques](https://twitter.com/pedro_designer/)
+
+* [WordPress - Belo Horizonte](http://www.meetup.com/WordPressBeloHorizonte) - Meetup sobre WordPress organizado por [https://twitter.com/valeriosza]
 
 ## Paraná
 
@@ -43,9 +45,12 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 
 *Meetups sobre desenvolvimento web no estado do Rio de Janeiro.*
 
-* [RioJS](http://riojs.org/) - Meetup sobre Javascript.
-* [Ruby on Rio](http://rubyonrio.org/) - Meetup sobre Ruby on Rails.
 * [Horaextra](http://horaextra.org/) - Meetup de desenvolvedores para troca de ideias sobre diversas tecnologias.
+
+* [RioJS](http://riojs.org/) - Meetup sobre Javascript.
+
+* [Ruby on Rio](http://rubyonrio.org/) - Meetup sobre Ruby on Rails.
+
 * [WordPress - Rio de Janeiro](http://www.meetup.com/wp-rio) - Meetup WordPress organizado por [Guga Alves](https://twitter.com/GugaAlves) e [Cadu Castro](https://twitter.com/castroalves)
 
 ## Rio Grande do Sul
@@ -53,7 +58,9 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 *Meetups sobre desenvolvimento web no estado do Rio Grande do Sul.*
 
 * [FEMUG-RS](http://www.meetup.com/FEMUG-RS/) - Meetup sobre frontend organizado por [Jean Carlo Emer](https://twitter.com/jcemer)
+
 * [MongoDB-RS](http://www.meetup.com/Rio-Grande-do-Sul-MongoDB-User-Group/) - Meetup sobre MongoDB organizado por [Ricardo Negri](https://twitter.com/riconegri) e [Matheus Caruccio](https://twitter.com/MateusCaruccio)
+
 * [WordPress - Porto Alegre](http://www.meetup.com/wp-poa/) - Meetup sobre WordPress organizado por [Rafael Ehlers](https://twitter.com/rafaehlers)
 
 ## Santa Catarina
@@ -61,6 +68,7 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 *Meetups sobre desenvolvimento web no estado de Santa Catarina.*
 
 * [Floripa Devs Meetup](http://floripajs.org/) - Meetup sobre desenvolvimento organizado por um bando de geeks [FloripaJS](https://twitter.com/FloripaJS)
+
 * [WordPress - Joinville](http://www.meetup.com/wpjoinville/) - Meetup sobre WordPress organizado por [Fernando Daciuk](https://twitter.com/fdaciuk)
 
 ## São Paulo
@@ -68,15 +76,27 @@ Lista de meetups voltados para desenvolvimento web no Brasil.
 *Meetups sobre desenvolvimento web no estado de São Paulo.*
 
 * [AngularJS - São Paulo](http://www.meetup.com/AngularJS-Sao-Paulo/) - Meetup sobre AngularJS organizado por [Ciro Nunes](https://twitter.com/cironunesdev) e [Henrique Dubugras](https://twitter.com/hdubugras)
+
 * [CSS - São Paulo](http://www.meetup.com/CSS-SP/) - Meetup sobre CSS organizado por [Raphael Fabeni](https://twitter.com/raphaelfabeni) e [Felipe Fialho](https://twitter.com/LFeh)
-* [DevInterior - Ribeirão Preto](http://www.meetup.com/devinterior/) - Meetup sobre desenvolvimento em geral organizado por [Caio Tarifa](https://twitter.com/caiotarifa)
-* [FDG - Interior](http://www.meetup.com/fdginterior) - Meetup sobre desenvolvimento Front-End em geral. Organizado por [Christian Freitas](https://twitter.com/chrfreitas) e [Douglas Oliveira](https://twitter.com/doidz)
-* [FEMUG-SP](http://femug.com/cgi-bin/mailman/listinfo/sp) - Meetup sobre frontend organizado por [Daniel Filho](https://twitter.com/danielfilho)
-* [Meteor - São Paulo](http://www.meetup.com/Meteor-Sao-Paulo/) - Meetup sobre Meteor organizado por [Leonardo Grijó](http://twitter.com/leonardogrijo)
-* [NodeBR - São Paulo](http://www.meetup.com/NodeBR-Sao-Paulo/) - Meetup sobre Node.js organizado por [Allan Hoffmeister](https://twitter.com/alan_hoff)
-* [PHPSP](http://www.meetup.com/php-sp/) - Meetup sobre PHP organizado por [Anderson Casimiro](https://twitter.com/duodraco)
-* [Web Performance SP](http://www.meetup.com/Web-Performance-SP) - Meetup sobre performance organizado por Alex Soares
-* [WordPress - São Paulo](http://www.meetup.com/wpsampa/) - Meetup sobre WordPress organizado por [Claudio Sanches](https://twitter.com/claudiosmweb), [Deblyn Padro](https://www.facebook.com/deblynprado) e [Rafael Funchal](https://twitter.com/RafaelFunchal)
-* [santos.frontend()](http://www.meetup.com/Santos-Front-end/) - Meetup sobre front-end organizado por [Hugo Bessa](https://github.com/hugobessaa) e [William Costa](https://github.com/williamcosta)
-* [santos.backend()](http://www.meetup.com/santos-backend/) - Meetup sobre back-end organizado por [Nicholas Eduardo](https://github.com/nicholasess)
+
 * [devbeers - São Paulo](http://www.meetup.com/devbeers-Sao-Paulo/) - Meetup sobre desenvolvimento em geral organizado por [Heitor Tashiro Sergent](https://twitter.com/heitortsergent), [Thamara Hessel](https://twitter.com/ThamaraHessel), [Éverton Ribeiro](https://twitter.com/nuxlli) e [Luis Cipriani](https://twitter.com/lfcipriani)
+
+* [DevInterior - Ribeirão Preto](http://www.meetup.com/devinterior/) - Meetup sobre desenvolvimento em geral organizado por [Caio Tarifa](https://twitter.com/caiotarifa)
+
+* [FDG - Interior](http://www.meetup.com/fdginterior) - Meetup sobre desenvolvimento Front-End em geral. Organizado por [Christian Freitas](https://twitter.com/chrfreitas) e [Douglas Oliveira](https://twitter.com/doidz)
+
+* [FEMUG-SP](http://femug.com/cgi-bin/mailman/listinfo/sp) - Meetup sobre frontend organizado por [Daniel Filho](https://twitter.com/danielfilho)
+
+* [Meteor - São Paulo](http://www.meetup.com/Meteor-Sao-Paulo/) - Meetup sobre Meteor organizado por [Leonardo Grijó](http://twitter.com/leonardogrijo)
+
+* [NodeBR - São Paulo](http://www.meetup.com/NodeBR-Sao-Paulo/) - Meetup sobre Node.js organizado por [Allan Hoffmeister](https://twitter.com/alan_hoff)
+
+* [PHPSP](http://www.meetup.com/php-sp/) - Meetup sobre PHP organizado por [Anderson Casimiro](https://twitter.com/duodraco)
+
+* [santos.backend()](http://www.meetup.com/santos-backend/) - Meetup sobre back-end organizado por [Nicholas Eduardo](https://github.com/nicholasess)
+
+* [santos.frontend()](http://www.meetup.com/Santos-Front-end/) - Meetup sobre front-end organizado por [Hugo Bessa](https://github.com/hugobessaa) e [William Costa](https://github.com/williamcosta)
+
+* [Web Performance SP](http://www.meetup.com/Web-Performance-SP) - Meetup sobre performance organizado por Alex Soares
+
+* [WordPress - São Paulo](http://www.meetup.com/wpsampa/) - Meetup sobre WordPress organizado por [Claudio Sanches](https://twitter.com/claudiosmweb), [Deblyn Padro](https://www.facebook.com/deblynprado) e [Rafael Funchal](https://twitter.com/RafaelFunchal)


### PR DESCRIPTION
Adicionei uma doc de contribuição para que tenhamos um padrão nos novos Meetups recebidos -> Ordem alfabética e com espaçamento entre cada Meetup. 

O espaçamento tanto melhora a leitura quanto facilita na hora de inserir novos Meetups, pois os links estavam todos grudados e dificultava entender onde acabava o quê além de "pesar" o olho.

Espero que seja útil :smile: ty